### PR TITLE
Roll back to Mongodb 4.4

### DIFF
--- a/welaser/docker-compose.yml
+++ b/welaser/docker-compose.yml
@@ -105,7 +105,7 @@ services:
   # Database (ORION)
   mongo-db:
     restart: always
-    image: mongo:5.0
+    image: mongo:4.4
     hostname: mongo-db
     container_name: mongo-db
     expose:


### PR DESCRIPTION
MongoDB 5.0+ requires a CPU with AVX support
https://jira.mongodb.org/browse/SERVER-54407